### PR TITLE
Fix missing include LogStream.h

### DIFF
--- a/src/object-tracking-viewer/src/Viewer.cpp
+++ b/src/object-tracking-viewer/src/Viewer.cpp
@@ -13,6 +13,7 @@
 
 #include <yarp/eigen/Eigen.h>
 #include <yarp/os/ResourceFinder.h>
+#include <yarp/os/LogStream.h>
 #include <yarp/sig/Vector.h>
 
 #include <Eigen/Dense>

--- a/src/object-tracking/src/PFilter.cpp
+++ b/src/object-tracking/src/PFilter.cpp
@@ -10,6 +10,7 @@
 #include <BayesFilters/utils.h>
 
 #include <yarp/eigen/Eigen.h>
+#include <yarp/os/LogStream.h>
 
 using namespace bfl;
 using namespace Eigen;

--- a/src/object-tracking/src/iCubHandContactsModel.cpp
+++ b/src/object-tracking/src/iCubHandContactsModel.cpp
@@ -8,6 +8,7 @@
 #include <iCubHandContactsModel.h>
 
 #include <yarp/eigen/Eigen.h>
+#include <yarp/os/LogStream.h>
 
 using namespace Eigen;
 using namespace yarp::eigen;


### PR DESCRIPTION
This PR fixes the compilation errors that show up upon the latest changes in yarp/devel (see https://github.com/robotology/yarp/pull/2006).

Basically, YARP headers now include what is strictly required inducing downstream projects to revise the list of necessary `#include`.